### PR TITLE
README.rst: compatability => compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ as well as 3.3 and up. 3.2 was supported by version 0.4, but with setuptools and
 pip no longer supporting 3.2, we cannot make any statement about 3.2
 compatibility.
 
-Compatability
+Compatibility
 `````````````
 
 The ``funcsigs`` backport has been tested against:
@@ -30,10 +30,10 @@ The ``funcsigs`` backport has been tested against:
 
 Continuous integration testing is provided by `Travis CI`_.
 
-Under Python 2.x there is a compatability issue when a function is assigned to
+Under Python 2.x there is a compatibility issue when a function is assigned to
 the ``__wrapped__`` property of a class after it has been constructed.
 Similiarily there under PyPy directly passing the ``__call__`` method of a
-builtin is also a compatability issues.  Otherwise the functionality is
+builtin is also a compatibility issues.  Otherwise the functionality is
 believed to be uniform between both Python2 and Python3.
 
 Issues


### PR DESCRIPTION
```
[marca@marca-mac2 ~]$ dict compatability
No definitions found for "compatability", perhaps you mean:
gcide:  comparability  Compatibility
wn:  comparability  compatibility
moby-thesaurus:  compatibility
```
