### PR TITLE
Add a failing test for class method with varargs only

### DIFF
--- a/tests/test_funcsigs.py
+++ b/tests/test_funcsigs.py
@@ -81,12 +81,16 @@ class TestFunctionSignatures(unittest.TestCase):
                 pass
             def method_with_args(self, a):
                 pass
+            def method_with_varargs(*args):
+                pass
         self.assertEqual(self.signature(Test.method),
                 (((('self', Ellipsis, Ellipsis, self_kind)),), Ellipsis))
         self.assertEqual(self.signature(Test.method_with_args), ((
                 ('self', Ellipsis, Ellipsis, self_kind),
                 ('a', Ellipsis, Ellipsis, "positional_or_keyword"),
                 ), Ellipsis))
+        self.assertEqual(self.signature(Test.method_with_varargs), ((
+                ('args', Ellipsis, Ellipsis, "var_positional"),), Ellipsis))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
same diff as https://github.com/aliles/funcsigs/pull/22

> I got here from testing-cabal/mock#338. It seems like a poor assumption that the first argument to any type of class method is going to be positional_only self (https://github.com/aliles/funcsigs/blob/master/funcsigs/__init__.py#L61). The @contextmanager decorator for example returns a function with a signature like (_args. *_kwargs) since it might be used on either a function or a class method.
