### PR TITLE
Deal with unbound methods like foo(*args).

### DIFF
--- a/funcsigs/__init__.py
+++ b/funcsigs/__init__.py
@@ -61,18 +61,29 @@ def signature(obj):
     if isinstance(obj, types.MethodType):
         sig = signature(obj.__func__)
         if obj.__self__ is None:
-            # Unbound method: the first parameter becomes positional-only
-            if sig.parameters:
-                first = sig.parameters.values()[0].replace(
-                    kind=_POSITIONAL_ONLY)
-                return sig.replace(
-                    parameters=(first,) + tuple(sig.parameters.values())[1:])
-            else:
-                return sig
+            # Unbound method - preserve as-is.
+            return sig
         else:
-            # In this case we skip the first parameter of the underlying
-            # function (usually `self` or `cls`).
-            return sig.replace(parameters=tuple(sig.parameters.values())[1:])
+            # Bound method. Eat self - if we can.
+            params = tuple(sig.parameters.values())
+
+            if not params or params[0].kind in (_VAR_KEYWORD, _KEYWORD_ONLY):
+                raise ValueError('invalid method signature')
+
+            kind = params[0].kind
+            if kind in (_POSITIONAL_OR_KEYWORD, _POSITIONAL_ONLY):
+                # Drop first parameter:
+                # '(p1, p2[, ...])' -> '(p2[, ...])'
+                params = params[1:]
+            else:
+                if kind is not _VAR_POSITIONAL:
+                    # Unless we add a new parameter type we never
+                    # get here
+                    raise ValueError('invalid argument type')
+                # It's a var-positional parameter.
+                # Do nothing. '(*args[, ...])' -> '(*args[, ...])'
+
+            return sig.replace(parameters=params)
 
     try:
         sig = obj.__signature__

--- a/tests/test_funcsigs.py
+++ b/tests/test_funcsigs.py
@@ -70,18 +70,22 @@ class TestFunctionSignatures(unittest.TestCase):
         doctest.testfile('../README.rst')
 
     def test_unbound_method(self):
-        if sys.version_info < (3,):
-            self_kind = "positional_only"
-        else:
-            self_kind = "positional_or_keyword"
+        self_kind = "positional_or_keyword"
         class Test(object):
             def method(self):
                 pass
             def method_with_args(self, a):
                 pass
-        self.assertEqual(self.signature(Test.method),
-                (((('self', Ellipsis, Ellipsis, self_kind)),), Ellipsis))
-        self.assertEqual(self.signature(Test.method_with_args), ((
-                ('self', Ellipsis, Ellipsis, self_kind),
-                ('a', Ellipsis, Ellipsis, "positional_or_keyword"),
+            def method_with_varargs(*args):
+                pass
+        self.assertEqual(
+            self.signature(Test.method),
+            (((('self', Ellipsis, Ellipsis, self_kind)),), Ellipsis))
+        self.assertEqual(
+            self.signature(Test.method_with_args),
+            ((('self', Ellipsis, Ellipsis, self_kind),
+              ('a', Ellipsis, Ellipsis, "positional_or_keyword"),
                 ), Ellipsis))
+        self.assertEqual(
+            self.signature(Test.method_with_varargs),
+            ((('args', Ellipsis, Ellipsis, "var_positional"),), Ellipsis))


### PR DESCRIPTION
Just copied the relevant code from the 3.6 stdlib.

This is a clear defect, and may help with testing-cabal/mock#338.

Co-Authored-By: Robert Collins rbtcollins@hpe.com
