### PR TITLE
Fix #20: setup_requires setuptools 17.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     extras_require = {
         ':python_version<"2.7"': ['ordereddict'],
     },
+    setup_requires = ["setuptools>=17.1"],
     classifiers = [
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
That is the release that < in markers started working.

This still gives a poor user experience when an older setuptools is
installed, but at least folk reading setup.py will see the version
they need.
