### PR TITLE
Add 3.5's apply_defaults method to BoundArguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,25 +273,8 @@ function.
 
          Arguments for which :meth:`Signature.bind` or
          :meth:`Signature.bind_partial` relied on a default value are skipped.
-         However, if needed, it is easy to include them.
-
-      ::
-
-        >>> def foo(a, b=10):
-        ...     pass
-
-        >>> sig = signature(foo)
-        >>> ba = sig.bind(5)
-
-        >>> ba.args, ba.kwargs
-        ((5,), {})
-
-        >>> for param in sig.parameters.values():
-        ...     if param.name not in ba.arguments:
-        ...         ba.arguments[param.name] = param.default
-
-        >>> ba.args, ba.kwargs
-        ((5, 10), {})
+         However, if needed, use :meth:`BoundArguments.apply_defaults` to add
+         them.
 
 
    .. attribute:: BoundArguments.args
@@ -303,6 +286,24 @@ function.
 
       A dict of keyword arguments values.  Dynamically computed from the
       :attr:`arguments` attribute.
+	  
+   .. method:: BoundArguments.apply_defaults()
+
+      Set default values for missing arguments.
+
+      For variable-positional arguments (``*args``) the default is an
+      empty tuple.
+
+      For variable-keyword arguments (``**kwargs``) the default is an
+      empty dict.
+
+      ::
+
+        >>> def foo(a, b='ham', *args): pass
+        >>> ba = inspect.signature(foo).bind('spam')
+        >>> ba.apply_defaults()
+        >>> ba.arguments
+        OrderedDict([('a', 'spam'), ('b', 'ham'), ('args', ())])
 
    The :attr:`args` and :attr:`kwargs` properties can be used to invoke
    functions::

--- a/funcsigs/__init__.py
+++ b/funcsigs/__init__.py
@@ -439,6 +439,34 @@ class BoundArguments(object):
 
         return kwargs
 
+    def apply_defaults(self):
+        """Set default values for missing arguments.
+
+        For variable-positional arguments (*args) the default is an
+        empty tuple.
+
+        For variable-keyword arguments (**kwargs) the default is an
+        empty dict.
+        """
+        arguments = self.arguments
+        new_arguments = []
+        for name, param in self._signature.parameters.items():
+            try:
+                new_arguments.append((name, arguments[name]))
+            except KeyError:
+                if param.default is not _empty:
+                    val = param.default
+                elif param.kind is _VAR_POSITIONAL:
+                    val = ()
+                elif param.kind is _VAR_KEYWORD:
+                    val = {}
+                else:
+                    # This BoundArguments was likely produced by
+                    # Signature.bind_partial().
+                    continue
+                new_arguments.append((name, val))
+        self.arguments = OrderedDict(new_arguments)
+
     def __hash__(self):
         msg = "unhashable type: '{0}'".format(self.__class__.__name__)
         raise TypeError(msg)


### PR DESCRIPTION
Patch for issue #28 

This is the current code and docs from CPython, and a very slightly slightly modified test, to move the Python 3-only stuff (annotations and keyword-only arguments) into a separate function from the rest of the test code.
