### PR TITLE
Use a more compatable way to get wrapper_descriptor and method_wrapper

### DIFF
--- a/funcsigs/__init__.py
+++ b/funcsigs/__init__.py
@@ -20,8 +20,8 @@ from funcsigs.version import __version__
 __all__ = ['BoundArguments', 'Parameter', 'Signature', 'signature']
 
 
-_WrapperDescriptor = type(type.__call__)
-_MethodWrapper = type(all.__call__)
+_WrapperDescriptor = type(bytearray.__add__)
+_MethodWrapper = type(u'str'.__add__)
 
 _NonUserDefinedCallables = (_WrapperDescriptor,
                             _MethodWrapper,


### PR DESCRIPTION
The original code use type(type.**call**) to get the type
`wrapper_descriptor` and use `type(all.__call__)` to get type
`method_wrapper`. according the comment in here:
https://github.com/Daetalus/funcsigs/blob/master/funcsigs/__init__.py#L170.
It could avoid infinite recursive or sefault.

In Pyston, the type of `type.__call__` is `instancemethod`. So it will
cause segfault. I change it to `type(bytearray.__add__)`, because in
Pyston, its type is `wrapper_descriptor`, this is also work in CPython
2.x and CPython 3.x.

More information, please see https://github.com/scikit-learn/scikit-learn/pull/7162.
