### PR TITLE
Fix deepcopy issue on _ParameterKind

### DIFF
--- a/funcsigs/__init__.py
+++ b/funcsigs/__init__.py
@@ -201,6 +201,9 @@ class _ParameterKind(int):
         obj._name = kwargs['name']
         return obj
 
+    def __deepcopy__(self, memo):
+        return type(self)(self, name=self._name)
+        
     def __str__(self):
         return self._name
 

--- a/tests/test_funcsigs.py
+++ b/tests/test_funcsigs.py
@@ -1,5 +1,6 @@
 import unittest2 as unittest
 
+import copy
 import doctest
 import sys
 
@@ -89,3 +90,9 @@ class TestFunctionSignatures(unittest.TestCase):
         self.assertEqual(
             self.signature(Test.method_with_varargs),
             ((('args', Ellipsis, Ellipsis, "var_positional"),), Ellipsis))
+
+    def test_deepcopy(self):
+	def test(*args, **kwargs):
+	    pass
+        sig = self.signature(test)
+	self.assertEqual(sig, copy.deepcopy(sig))

--- a/tests/test_funcsigs.py
+++ b/tests/test_funcsigs.py
@@ -92,7 +92,7 @@ class TestFunctionSignatures(unittest.TestCase):
             ((('args', Ellipsis, Ellipsis, "var_positional"),), Ellipsis))
 
     def test_deepcopy(self):
-	def test(*args, **kwargs):
-	    pass
+        def test(*args, **kwargs):
+            pass
         sig = self.signature(test)
-	self.assertEqual(sig, copy.deepcopy(sig))
+        self.assertEqual(sig, copy.deepcopy(sig))


### PR DESCRIPTION
Fixes #34 by adding an explicit deepcopy method on _ParameterKind (thus making the entire Signature object deepcopy-able)